### PR TITLE
Update copyright and license headers according to Eclipse Foundation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,11 +36,12 @@ A proper header must be in place for any file contributed to Eclipse OneOFour. F
 /*******************************************************************************
  * Copyright (c) <year> <legal entity> and others
  *
- * All rights reserved. This program and the accompanying materials
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
- *
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
  ```
 
@@ -52,10 +53,12 @@ A proper header must be in place for any file contributed to Eclipse OneOFour. F
  /*******************************************************************************
  * Copyright (c) <year> <legal entity> and others
  *
- * All rights reserved. This program and the accompanying materials
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     <legal entity>

--- a/org.eclipse.oneofour.client.data.testing/src/test/java/org/eclipse/oneofour/client/data/testing/Application.java
+++ b/org.eclipse.oneofour.client.data.testing/src/test/java/org/eclipse/oneofour/client/data/testing/Application.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2015 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/AbstractDataProcessor.java
+++ b/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/AbstractDataProcessor.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataHandler.java
+++ b/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataHandler.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataListener.java
+++ b/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataListener.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2015 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataModule.java
+++ b/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataModule.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataModuleContext.java
+++ b/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataModuleContext.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataModuleHandler.java
+++ b/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataModuleHandler.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataModuleOptions.java
+++ b/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataModuleOptions.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataProcessor.java
+++ b/org.eclipse.oneofour.client.data/src/main/java/org/eclipse/oneofour/client/data/DataProcessor.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client/src/main/java/org/eclipse/oneofour/client/AutoConnectClient.java
+++ b/org.eclipse.oneofour.client/src/main/java/org/eclipse/oneofour/client/AutoConnectClient.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client/src/main/java/org/eclipse/oneofour/client/Client.java
+++ b/org.eclipse.oneofour.client/src/main/java/org/eclipse/oneofour/client/Client.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2015 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client/src/main/java/org/eclipse/oneofour/client/ClientModule.java
+++ b/org.eclipse.oneofour.client/src/main/java/org/eclipse/oneofour/client/ClientModule.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.client/src/main/java/org/eclipse/oneofour/client/ConnectionStateListener.java
+++ b/org.eclipse.oneofour.client/src/main/java/org/eclipse/oneofour/client/ConnectionStateListener.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/ASDUAddressType.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/ASDUAddressType.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/CauseOfTransmissionType.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/CauseOfTransmissionType.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2015 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/InformationObjectAddressType.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/InformationObjectAddressType.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/ProtocolOptions.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/ProtocolOptions.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/APCIBase.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/APCIBase.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/APCIType.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/APCIType.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/APDUDecoder.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/APDUDecoder.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/APDUEncoder.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/APDUEncoder.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/AckBuffer.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/AckBuffer.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/Constants.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/Constants.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/InformationTransfer.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/InformationTransfer.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/MessageChannel.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/MessageChannel.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/MessageSource.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/MessageSource.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/Supervisory.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/Supervisory.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/Timer.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/Timer.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/TimerHandler.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/TimerHandler.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/UnnumberedControl.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/apci/UnnumberedControl.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/ASDUHeader.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/ASDUHeader.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/Dumpable.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/Dumpable.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/Dumper.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/Dumper.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/DumperHelper.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/DumperHelper.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/MessageCodec.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/MessageCodec.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/MessageManager.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/MessageManager.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/ReflectionMessageCodec.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/ReflectionMessageCodec.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/ValidationException.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/ValidationException.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/ValidationHelper.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/ValidationHelper.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractDoublePointBaseSingle.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractDoublePointBaseSingle.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractInformationObjectMessage.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractInformationObjectMessage.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractMeasuredValueFloatingPoint.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractMeasuredValueFloatingPoint.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractMeasuredValueScaled.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractMeasuredValueScaled.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractMessage.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractMessage.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractSingleBooleanBaseSingle.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/AbstractSingleBooleanBaseSingle.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/DataTransmissionMessage.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/DataTransmissionMessage.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/DoubleCommand.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/DoubleCommand.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/DoublePointInformationSequence.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/DoublePointInformationSequence.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/DoublePointInformationSingle.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/DoublePointInformationSingle.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/DoublePointInformationTimeSingle.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/DoublePointInformationTimeSingle.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/EncodeHelper.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/EncodeHelper.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/Encodeable.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/Encodeable.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/EndOfInitialization.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/EndOfInitialization.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/InterrogationCommand.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/InterrogationCommand.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueScaledSequence.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueScaledSequence.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueScaledSingle.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueScaledSingle.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueScaledTimeSingle.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueScaledTimeSingle.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueShortFloatingPointSequence.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueShortFloatingPointSequence.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueShortFloatingPointSingle.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueShortFloatingPointSingle.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueShortFloatingPointTimeSingle.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MeasuredValueShortFloatingPointTimeSingle.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MessageRegistrator.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MessageRegistrator.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MirrorableMessage.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/MirrorableMessage.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/ReadCommand.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/ReadCommand.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SetPointCommandScaledValue.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SetPointCommandScaledValue.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SetPointCommandShortFloatingPoint.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SetPointCommandShortFloatingPoint.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SingleCommand.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SingleCommand.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SinglePointInformationSequence.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SinglePointInformationSequence.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SinglePointInformationSingle.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SinglePointInformationSingle.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SinglePointInformationTimeSingle.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/message/SinglePointInformationTimeSingle.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/ASDU.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/ASDU.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/ASDUAddress.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/ASDUAddress.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/Cause.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/Cause.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/CauseOfTransmission.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/CauseOfTransmission.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/Causes.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/Causes.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/CustomCause.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/CustomCause.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/DoublePoint.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/DoublePoint.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/InformationEntry.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/InformationEntry.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/InformationObjectAddress.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/InformationObjectAddress.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/InformationStructure.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/InformationStructure.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/QualifierOfInterrogation.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/QualifierOfInterrogation.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/QualityInformation.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/QualityInformation.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/StandardCause.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/StandardCause.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/TypeHelper.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/TypeHelper.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/Value.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/asdu/types/Value.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/io/AbstractModuleHandler.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/io/AbstractModuleHandler.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/io/MirrorCommand.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/io/MirrorCommand.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/io/Module.java
+++ b/org.eclipse.oneofour.common/src/main/java/org/eclipse/oneofour/io/Module.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/TestEventBuffer.java
+++ b/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/TestEventBuffer.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/TestMessageSource.java
+++ b/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/TestMessageSource.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/model/DataChangeModelTest.java
+++ b/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/model/DataChangeModelTest.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016, 2017 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/model/MockChangeDataModel.java
+++ b/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/model/MockChangeDataModel.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/model/MockDataListener.java
+++ b/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/model/MockDataListener.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/model/MockMirrorCommand.java
+++ b/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/model/MockMirrorCommand.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016, 2017 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/model/StoppingTest.java
+++ b/org.eclipse.oneofour.server.data.tests/src/test/java/org/eclipse/oneofour/server/data/model/StoppingTest.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/AbstractBaseDataModel.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/AbstractBaseDataModel.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2017 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/BackgroundIterator.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/BackgroundIterator.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/ChannelWriter.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/ChannelWriter.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/ContextChannelWriter.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/ContextChannelWriter.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataListener.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataListener.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataListenerImpl.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataListenerImpl.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataModel.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataModel.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataModule.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataModule.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataModuleHandler.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataModuleHandler.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataModuleMessageSource.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataModuleMessageSource.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataModuleOptions.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DataModuleOptions.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DefaultSubscription.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/DefaultSubscription.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/FinallyFutureCallback.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/FinallyFutureCallback.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/Stopping.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/Stopping.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/Subscription.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/Subscription.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/AbstractMessageBuilder.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/AbstractMessageBuilder.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/EventBuffer.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/EventBuffer.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/EventQueue.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/EventQueue.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/MessageBuilder.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/MessageBuilder.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/MessageBuilderFactory.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/MessageBuilderFactory.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/SimpleBooleanBuilder.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/SimpleBooleanBuilder.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/SimpleFloatBuilder.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/SimpleFloatBuilder.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/SimpleScaledBuilder.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/event/SimpleScaledBuilder.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/BackgroundModel.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/BackgroundModel.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/BackgroundModelImpl.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/BackgroundModelImpl.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/BufferingChangeModel.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/BufferingChangeModel.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/ChangeDataModel.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/ChangeDataModel.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016, 2017 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/ChangeModel.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/ChangeModel.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/InstantChangeModel.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/InstantChangeModel.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/WriteModel.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/model/WriteModel.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/testing/SineDataModel.java
+++ b/org.eclipse.oneofour.server.data/src/main/java/org/eclipse/oneofour/server/data/testing/SineDataModel.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server.testing/src/test/java/org/eclipse/oneofour/server/testing/Application.java
+++ b/org.eclipse.oneofour.server.testing/src/test/java/org/eclipse/oneofour/server/testing/Application.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server/src/main/java/org/eclipse/oneofour/server/Server.java
+++ b/org.eclipse.oneofour.server/src/main/java/org/eclipse/oneofour/server/Server.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014, 2016 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.server/src/main/java/org/eclipse/oneofour/server/ServerModule.java
+++ b/org.eclipse.oneofour.server/src/main/java/org/eclipse/oneofour/server/ServerModule.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.tests/src/test/java/org/eclipse/oneofour/AsduAddressTest.java
+++ b/org.eclipse.oneofour.tests/src/test/java/org/eclipse/oneofour/AsduAddressTest.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2016 Red Hat Inc and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Red Hat Inc - initial API and implementation

--- a/org.eclipse.oneofour.tests/src/test/java/org/eclipse/oneofour/CauseTest.java
+++ b/org.eclipse.oneofour.tests/src/test/java/org/eclipse/oneofour/CauseTest.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.tests/src/test/java/org/eclipse/oneofour/apci/AckBufferTest.java
+++ b/org.eclipse.oneofour.tests/src/test/java/org/eclipse/oneofour/apci/AckBufferTest.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.tests/src/test/java/org/eclipse/oneofour/asdu/types/TimestampTest.java
+++ b/org.eclipse.oneofour.tests/src/test/java/org/eclipse/oneofour/asdu/types/TimestampTest.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2014 IBH SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/ExceptionHelper.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/ExceptionHelper.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2013 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/beans/AbstractPropertyChange.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/beans/AbstractPropertyChange.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2010 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/AbstractFuture.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/AbstractFuture.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2010 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/CallingFuture.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/CallingFuture.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2013 Jens Reimann and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Jens Reimann - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/CountingThreadPoolExecutor.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/CountingThreadPoolExecutor.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2011 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/DirectExecutor.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/DirectExecutor.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2013 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/ExecutorFuture.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/ExecutorFuture.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2011, 2012 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/ExecutorServiceExporterImpl.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/ExecutorServiceExporterImpl.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2017 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/ExecutorServiceExporterMXBean.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/ExecutorServiceExporterMXBean.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2012 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/ExportedExecutorService.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/ExportedExecutorService.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2015 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/FutureListener.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/FutureListener.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2010 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/FutureTask.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/FutureTask.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2010 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/InstantErrorFuture.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/InstantErrorFuture.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2010 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/InstantFuture.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/InstantFuture.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2010 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/InstantFutureBase.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/InstantFutureBase.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2010 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/IteratingFuture.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/IteratingFuture.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2013 Jens Reimann and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Jens Reimann - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/NamedThreadFactory.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/NamedThreadFactory.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2017 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/NotifyFuture.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/NotifyFuture.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2010 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/NotifyFutureImpl.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/NotifyFutureImpl.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2013 Jens Reimann and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Jens Reimann - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/ScheduledExportedExecutorService.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/ScheduledExportedExecutorService.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2015 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/TransformResultFuture.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/TransformResultFuture.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2013 Jens Reimann and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     Jens Reimann - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/internal/FutureTaskNotifier.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/internal/FutureTaskNotifier.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2011 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/task/DefaultTaskHandler.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/task/DefaultTaskHandler.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2010 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/task/ResultFutureHandler.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/task/ResultFutureHandler.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2013 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/task/ResultHandler.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/task/ResultHandler.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2013 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation

--- a/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/task/TaskHandler.java
+++ b/org.eclipse.oneofour.utils/src/main/java/org/eclipse/oneofour/utils/concurrent/task/TaskHandler.java
@@ -1,9 +1,12 @@
 /*******************************************************************************
  * Copyright (c) 2006, 2010 TH4 SYSTEMS GmbH and others.
- * All rights reserved. This program and the accompanying materials
+ * 
+ * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
  *     TH4 SYSTEMS GmbH - initial API and implementation


### PR DESCRIPTION
Update the copyright and license headers. Changes are:
- Remove no longer needed "All rights reserved"
- Add declared project licenses indicated using SPDX codes and expressions