### PR TITLE
Use dependencies with approved CQs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@
 
         <!-- Dependency versions -->
         <version.slf4j>1.7.30</version.slf4j>
-        <version.guava>29.0-jre</version.guava>
-        <version.netty>4.1.50.Final</version.netty>
-        <version.junit>5.6.2</version.junit>
+        <version.guava>28.2-jre</version.guava>
+        <version.netty>4.1.51.Final</version.netty>
+        <version.junit>5.6.0</version.junit>
     </properties>
 
     <modules>


### PR DESCRIPTION
- Netty: 4.1.50.Final -> 4.1.51.Final
- Guava: 29.0-jre -> 28.2-jre
- JUnit: 5.6.2 -> 5.6.0